### PR TITLE
Fixing crashes when client abruptly closes the conneciton.

### DIFF
--- a/include/tasks/net/uwsgi_thrift_async_processor.h
+++ b/include/tasks/net/uwsgi_thrift_async_processor.h
@@ -94,10 +94,13 @@ public:
                 if (!error_code()) {
                     worker->signal_call([this] (struct ev_loop*) {
                             send_response();
+                            // Allow cleanup now.
+                            enable_dispose();
                         });
+                } else {
+                    // Allow cleanup now
+                    enable_dispose();
                 }
-                // Allow cleanup now
-                enable_dispose();
             });
 
         try {


### PR DESCRIPTION
Fix for crashes when the client abruptly closes the connection. Also, this is a possible solution for the crashes caused by calling finish() from another threads.
